### PR TITLE
Shrink generated packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,7 @@ const generateData = function(version) {
 		'.gitignore',
 		'.npmignore',
 		'.npmrc',
+		'decode-property-map.js',
 		'decode-ranges.js',
 	].forEach(function(file) {
 		cp.sync(

--- a/index.js
+++ b/index.js
@@ -173,6 +173,7 @@ const generateData = function(version) {
 		'.gitignore',
 		'.npmignore',
 		'.npmrc',
+		'decode-ranges.js',
 	].forEach(function(file) {
 		cp.sync(
 			path.resolve(staticPath, file),

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -13,7 +13,8 @@ const gzipInline = function(data) {
 	}
 	const json = jsesc(data, { 'json': true });
 	const gzipBuffer = zlib.gzipSync(json);
-	return `JSON.parse(require('zlib').gunzipSync(${ jsesc(gzipBuffer) }))`;
+	const str = gzipBuffer.toString('base64');
+	return `JSON.parse(require('zlib').gunzipSync(Buffer.from('${ str }','base64')))`;
 };
 
 const range = function(start, stop) {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -6,7 +6,7 @@ const zlib = require('zlib');
 const jsesc = require('jsesc');
 const mkdirp = require('mkdirp');
 const regenerate = require('regenerate');
-const decodeRanges = require('../static/decode-ranges');
+const decodeRanges = require('../static/decode-ranges.js');
 
 const gzipInline = function(data) {
 	if (data instanceof Map) {
@@ -55,7 +55,7 @@ const samePropertyRuns = function(codePointProperties) {
 		}
 	}
 	return result;
-}
+};
 
 const writeFiles = function(options) {
 	const version = options.version;
@@ -119,12 +119,12 @@ const writeFiles = function(options) {
 
 		// Save the data to a file
 		let codePointsExports = `require('./ranges').flatMap(r=>Array.from(r.keys()))`;
-		let symbolsExports = `require('./ranges').flatMap(r=>Array.from(r.values()))`;
+		let symbolsExports = `require('./ranges.js').flatMap(r=>Array.from(r.values()))`;
 		if (!isCaseFolding) {
 			const sortedCodePoints = [...codePoints].sort((a, b) => a - b);
 			fs.writeFileSync(
 				path.resolve(dir, 'ranges.js'),
-				`module.exports=require('../../decode-ranges')('${
+				`module.exports=require('../../decode-ranges.js')('${
 					decodeRanges.encode(sortedCodePoints)
 				}')`
 			);
@@ -180,13 +180,13 @@ const writeFiles = function(options) {
 				`module.exports=new Map(${
 					jsesc(flatPairs)
 				}.map((v,i,a)=>pair(i&1,a[i^1],v)))`
-			].join('\n');
+			].join(';');
 		} else { // `categories/index.js`
 			// or `Bidi_Class/index.js`
 			// or `bidi-brackets/index.js`
 			// or `Names/index.js`
 			const flatRuns = samePropertyRuns(auxMap[type]);
-			output = `module.exports=require('../decode-property-map')(${
+			output = `module.exports=require('../decode-property-map.js')(${
 				gzipInline(flatRuns)
 			})`;
 		}

--- a/static/decode-property-map.js
+++ b/static/decode-property-map.js
@@ -1,0 +1,20 @@
+/**
+  * Generate [codePoint, value] pairs from RLE array of values.
+  */
+function * generateEntries(runs) {
+	const len = runs.length - 2;
+	for (let cp = 0, i = 0; i < len; ) {
+		cp += runs[i++];
+		const end = cp + runs[i++];
+		const value = runs[i++];
+		while (cp < end) {
+			yield [cp++, value];
+		}
+	}
+}
+
+function decodePropertyMap(runs) {
+	return new Map(generateEntries(runs));
+}
+
+module.exports = decodePropertyMap;

--- a/static/decode-ranges.js
+++ b/static/decode-ranges.js
@@ -1,5 +1,5 @@
 const base64enc =
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+	'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 
 const base64dec = Object.freeze(Object.fromEntries(
 	Array.from(base64enc, (c, i) => [c, i])

--- a/static/decode-ranges.js
+++ b/static/decode-ranges.js
@@ -1,0 +1,114 @@
+const base64enc =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+const base64dec = Object.freeze(Object.fromEntries(
+	Array.from(base64enc, (c, i) => [c, i])
+));
+
+class UnicodeRange {
+	constructor(begin, end) {
+		this.begin = begin;
+		this.end = end;
+		this.length = end - begin;
+	}
+	*keys() {
+		const { begin, end } = this;
+		for (let i = begin; i < end; ++i) {
+			yield i;
+		}
+	}
+	*values() {
+		const { begin, end } = this;
+		for (let i = begin; i < end; ++i) {
+			yield String.fromCodePoint(i);
+		}
+	}
+}
+
+/**
+  * Base64 decode variable-length deltas (5/10/15/21-bit).
+  */
+function decodeDeltas(input) {
+	const output = [];
+	for (let i = 0; i < input.length; ) {
+		let x = base64dec[input[i++]];
+		switch (x & 56) {
+			case 32:
+			case 40:
+				x = (x & 15) << 6;
+				x |= base64dec[input[i++]];
+				break;
+			case 48:
+				x = (x & 7) << 12;
+				x |= base64dec[input[i++]] << 6;
+				x |= base64dec[input[i++]];
+				break;
+			case 56:
+				x = (x & 7) << 18;
+				x |= base64dec[input[i++]] << 12;
+				x |= base64dec[input[i++]] << 6;
+				x |= base64dec[input[i++]];
+				break;
+		}
+		output.push(x);
+	}
+	return output;
+}
+
+/**
+  * Base64 encode variable-length deltas (5/10/15/21-bit).
+  */
+function encodeDeltas(input) {
+	const output = [];
+	for (let i = 0; i < input.length; ++i) {
+		const x = input[i];
+		if ((x >> 5) === 0) {
+			output.push(x);
+		} else if ((x >> 10) === 0) {
+			output.push(32 + (x >> 6), x);
+		} else if ((x >> 15) === 0) {
+			output.push(48 + (x >> 12), x >> 6, x);
+		} else {
+			console.assert((x >> 21) === 0, `delta ${x} out of range`);
+			output.push(56 + (x >> 18), x >> 12, x >> 6, x);
+		}
+	}
+	return output.map(x => base64enc[x & 63]).join('');
+}
+
+/**
+  * RLE + base64 decode code point ranges.
+  */
+function decodeRanges(input) {
+	const deltas = decodeDeltas(input);
+	const ranges = [];
+	for (let end = -1, i = 1; i < deltas.length; i += 2) {
+		const begin = end + 1 + deltas[i - 1];
+		const length = 1 + deltas[i];
+		end = begin + length;
+		ranges.push(new UnicodeRange(begin, end));
+	}
+	return ranges;
+}
+
+/**
+  * RLE + base64 encode code point ranges.
+  */
+function encodeRanges(values) {
+	const deltas = [];
+	for (let end = -1, i = 0; i < values.length; ) {
+		const begin = values[i];
+		console.assert(begin > end, `code point ${begin} out of order`);
+		deltas.push(begin - end - 1);
+		end = begin + 1;
+		while (++i < values.length && values[i] === end) {
+			++end;
+		}
+		deltas.push(end - begin - 1);
+	}
+	return encodeDeltas(deltas);
+}
+
+module.exports = Object.defineProperty(
+	decodeRanges, 'encode', { value: encodeRanges }
+);


### PR DESCRIPTION
There is a glaring inefficiency in serialization of gzipped data, which is addressed by the first commit in this PR. Constructing gunzip input buffer from base64-encoded string instead of an array of numbers shrinks generated unicode-13 package from ~150MB down to ~60MB.

Subsequent two commits are a bit more complicated.

The second commit compresses binary properties. It comes from the observation that many generated `code-points.js` and `symbols.js` files contain long sequences of adjacent code points. These can be run-length encoded, and the lengths (which are often short) then encoded in variable-length base64 prefix code. This shrinks generated unicode-13 package from ~60MB down to ~15.5MB.

The third commit applies run-length encoding to named properties, shrinking the generated package down to ~13.5MB.
