### PR TITLE
fix: build Simple_Case_Mapping data

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,6 +148,12 @@ const generateData = function(version) {
 		'type': 'Names',
 		'subType': 'name-aliases'
 	}));
+	console.log('Parsing Unicode v%s simple case mappings…', version);
+	extend(dirMap, utils.writeFiles({
+		'version': version,
+		'map': parsers.parseSimpleCaseMapping(version),
+		'type': 'Simple_Case_Mapping'
+	}));
 	console.log('Parsing Unicode v%s `Special_Casing`…', version);
 	extend(dirMap, utils.writeFiles({
 		'version': version,


### PR DESCRIPTION
It turns out I removed the simple case mapping data build for debug purpose when working on the special casing data in #78.

I will see if there is anything I can do to improve the build performance.