### PR TITLE
Improve build performance

### DIFF
--- a/scripts/generate-data.js
+++ b/scripts/generate-data.js
@@ -2,7 +2,6 @@
 
 const resources = require('../data/resources.js');
 const generateData = require('../index.js');
-const utils = require('../scripts/utils.js');
 
 // -----------------------------------------------------------------------------
 
@@ -28,7 +27,9 @@ const complicatedWorkThatTakesTime = (resource, callback) => {
 		console.log('[%s] Worker %d \u2192 Unicode v%s',
 			getTime(), cluster.worker.id, version);
 
+		console.groupCollapsed();
 		generateData(version);
+		console.groupEnd();
 
 		complicatedWorkThatTakesTime(
 			resource.slice(1),
@@ -40,7 +41,7 @@ const complicatedWorkThatTakesTime = (resource, callback) => {
 	}
 };
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
 
 	for (let index = 0; index < numCPUs; index++) {
 		cluster.fork();

--- a/scripts/parse-blocks-scripts-properties.js
+++ b/scripts/parse-blocks-scripts-properties.js
@@ -88,6 +88,7 @@ const parseBlocksScriptsProperties = function(type, version) {
 
 const parseDerivedBinaryProperties = function(version) {
 	if (version === '3.1.1' || version === '3.1.0' || version === '3.0.1' || version === '3.0.0' || parseInt(version.split('.')[0], 10) < 3) {
+		throw new Error("Unexpected data");
 		// Unicode <= 3.1.1 does not provide derived-binary-properties,
 		// so we should derive Bidi_Mirrored from the UnicodeData
 		const source = utils.readDataFile(version, 'database');

--- a/scripts/parse-blocks-scripts-properties.js
+++ b/scripts/parse-blocks-scripts-properties.js
@@ -88,7 +88,6 @@ const parseBlocksScriptsProperties = function(type, version) {
 
 const parseDerivedBinaryProperties = function(version) {
 	if (version === '3.1.1' || version === '3.1.0' || version === '3.0.1' || version === '3.0.0' || parseInt(version.split('.')[0], 10) < 3) {
-		throw new Error("Unexpected data");
 		// Unicode <= 3.1.1 does not provide derived-binary-properties,
 		// so we should derive Bidi_Mirrored from the UnicodeData
 		const source = utils.readDataFile(version, 'database');

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -11,7 +11,7 @@ const gzipInline = function(data) {
 	if (data instanceof Map) {
 		return `new Map(${ gzipInline([...data]) })`;
 	}
-	const json = jsesc(data, { 'json': true });
+	const json = JSON.stringify(data);
 	const gzipBuffer = zlib.gzipSync(json);
 	const str = gzipBuffer.toString('base64');
 	return `JSON.parse(require('zlib').gunzipSync(Buffer.from('${ str }','base64')))`;


### PR DESCRIPTION
This PR contains commits from #82. I will rebase once that PR gets merged.

This PR fixed a performance regression introduced in #80 where we generated the bidi_mirroring_glyph data when enumerating the glyph mappings, although the final data is correct, this is apparently not desired.

<s>We also removed the cluster building approach because at this point, it is more efficient to run the V8 optimized code again and again for several seconds than forking multiple V8 processes simutaneously optimizing code which does not run for a very long time.</s>

Last we used the native `JSON.stringify` when generating the gzipped data. Because the data is gzipped and not human-readable anyway, there is not very much benefit running `jsesc` before gzip.

Unsurprisingly, the last commit generates lots of output diffs. However, they are equivalent for end users, so I didn't attach the output diff in this PR.

Runtime measured in my local environment (Apple M1 Max 10c)
```
# Current main:
$ time npm run build
npm run build  15.51s user 9.99s system 350% cpu 7.267 total

# This PR:
$ time npm run build
npm run build  9.01s user 10.30s system 297% cpu 6.497 total
```

<details>
<summary>The time spent on each task when processing Unicode 16.0.0 in this PR (Click to unfold)</summary>

```
Generating data for Unicode v16.0.0…
Parsing Unicode v16.0.0 `Bidi_Class`
bidi_class: 58.685ms
Parsing Unicode v16.0.0 `Script`…
scripts: 50.533ms
Parsing Unicode v16.0.0 `Script_Extensions`…
script extensions: 48.772ms
Parsing Unicode v16.0.0 properties…
properties: 13.801ms
Parsing Unicode v16.0.0 derived core properties…
derived properties: 36.039ms
Parsing Unicode v16.0.0 derived general category…
derived general category: 28.396ms
Parsing Unicode v16.0.0 derived normalization properties…
derived normalization properties: 51.644ms
Parsing Unicode v16.0.0 derived binary properties…
derived binary properties: 0.641ms
Parsing Unicode v16.0.0 composition exclusions…
compostion exclusions: 0.48ms
Parsing Unicode v16.0.0 `Case_Folding`…
case folding: 4.197ms
Parsing Unicode v16.0.0 `Block`…
block: 87.287ms
Parsing Unicode v16.0.0 `Bidi_Mirroring_Glyph`
bidi mirroring glyph: 1.353ms
Parsing Unicode v16.0.0 bidi brackets…
bidi brackets: 1.573ms
Parsing Unicode v16.0.0 `Line_Break`…
line break: 21.974ms
Parsing Unicode v16.0.0 `Word_Break`…
word break: 9.982ms
Parsing Unicode v16.0.0 binary emoji properties…
binary emoji properties: 6.312ms
Parsing Unicode v16.0.0 emoji sequence properties…
emoji sequence properties: 17.331ms
Parsing Unicode v16.0.0 `Names`…
names: 112.647ms
Parsing Unicode v16.0.0 Aliases…
aliases: 1.282ms
Parsing Unicode v16.0.0 simple case mappings…
simple case mappings: 23.97ms
Parsing Unicode v16.0.0 `Special_Casing`…
special casing: 6.342ms
```
</details>