### PR TITLE
feat: add ArabicShaping table (Joining_Type) — fixes #101

### DIFF
--- a/data/resources.mjs
+++ b/data/resources.mjs
@@ -115,6 +115,8 @@ const resources = [
 		'special-casing':
 			'https://unicode.org/Public/3.2-Update/SpecialCasing-3.2.0.txt',
 		'line-break': 'https://unicode.org/Public/3.2-Update/LineBreak-3.2.0.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/3.2-Update/ArabicShaping-3.2.0.txt',
 	},
 	{
 		version: '4.0.0',
@@ -135,6 +137,8 @@ const resources = [
 		'special-casing':
 			'https://unicode.org/Public/4.0-Update/SpecialCasing-4.0.0.txt',
 		'line-break': 'https://unicode.org/Public/4.0-Update/LineBreak-4.0.0.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/4.0-Update/ArabicShaping-4.0.0.txt',
 	},
 	{
 		version: '4.0.1',
@@ -155,6 +159,8 @@ const resources = [
 		'special-casing':
 			'https://unicode.org/Public/4.0-Update1/SpecialCasing-4.0.1.txt',
 		'line-break': 'https://unicode.org/Public/4.0-Update1/LineBreak-4.0.1.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/4.0-Update1/ArabicShaping-4.0.1.txt',
 	},
 	{
 		version: '4.1.0',
@@ -176,6 +182,8 @@ const resources = [
 		'special-casing': 'https://unicode.org/Public/4.1.0/ucd/SpecialCasing.txt',
 		'bidi-mirroring': 'https://unicode.org/Public/4.1.0/ucd/BidiMirroring.txt',
 		'line-break': 'https://unicode.org/Public/4.1.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/4.1.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/4.1.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -203,6 +211,8 @@ const resources = [
 		'special-casing': 'https://unicode.org/Public/5.0.0/ucd/SpecialCasing.txt',
 		'bidi-mirroring': 'https://unicode.org/Public/5.0.0/ucd/BidiMirroring.txt',
 		'line-break': 'https://unicode.org/Public/5.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/5.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/5.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -230,6 +240,8 @@ const resources = [
 		'special-casing': 'https://unicode.org/Public/5.1.0/ucd/SpecialCasing.txt',
 		'bidi-mirroring': 'https://unicode.org/Public/5.1.0/ucd/BidiMirroring.txt',
 		'line-break': 'https://unicode.org/Public/5.1.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/5.1.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/5.1.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -257,6 +269,8 @@ const resources = [
 		'special-casing': 'https://unicode.org/Public/5.2.0/ucd/SpecialCasing.txt',
 		'bidi-mirroring': 'https://unicode.org/Public/5.2.0/ucd/BidiMirroring.txt',
 		'line-break': 'https://unicode.org/Public/5.2.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/5.2.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/5.2.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -290,6 +304,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/6.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/6.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/6.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/6.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -324,6 +340,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/6.1.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/6.1.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/6.1.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/6.1.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -358,6 +376,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/6.2.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/6.2.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/6.2.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/6.2.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -393,6 +413,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/6.3.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/6.3.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/6.3.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/6.3.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -428,6 +450,8 @@ const resources = [
 		'bidi-mirroring': 'https://unicode.org/Public/7.0.0/ucd/BidiMirroring.txt',
 		'bidi-brackets': 'https://unicode.org/Public/7.0.0/ucd/BidiBrackets.txt',
 		'line-break': 'https://unicode.org/Public/7.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/7.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/7.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -463,6 +487,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/8.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/8.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/8.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/8.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -498,6 +524,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/9.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/9.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/9.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/9.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -533,6 +561,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/10.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/10.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/10.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/10.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -570,6 +600,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/11.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/11.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/11.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/11.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -617,6 +649,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/12.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/12.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/12.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/12.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -664,6 +698,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/12.1.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/12.1.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/12.1.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/12.1.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -711,6 +747,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/13.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/13.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/13.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/13.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -758,6 +796,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/14.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/14.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/14.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/14.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -805,6 +845,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/15.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/15.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/15.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/15.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -852,6 +894,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/15.1.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/15.1.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/15.1.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/15.1.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -899,6 +943,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/16.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/16.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/16.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/16.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -946,6 +992,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/17.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/17.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/17.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/17.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':
@@ -993,6 +1041,8 @@ const resources = [
 		'indic-syllabic-category':
 			'https://unicode.org/Public/18.0.0/ucd/IndicSyllabicCategory.txt',
 		'line-break': 'https://unicode.org/Public/18.0.0/ucd/LineBreak.txt',
+		'arabic-shaping':
+			'https://unicode.org/Public/18.0.0/ucd/ArabicShaping.txt',
 		'grapheme-cluster-break':
 			'https://unicode.org/Public/18.0.0/ucd/auxiliary/GraphemeBreakProperty.txt',
 		'word-break':

--- a/index.mjs
+++ b/index.mjs
@@ -17,6 +17,7 @@ import parseSpecialCasing from './scripts/parse-special-casing.mjs';
 import parseSimpleCaseMapping from './scripts/parse-simple-case-mapping.mjs';
 import parseGraphemeWordSentenceBreak from './scripts/parse-grapheme-word-sentence-break.mjs';
 import parseVerticalOrientation from './scripts/parse-vertical-orientation.mjs';
+import parseArabicShaping from './scripts/parse-arabic-shaping.mjs';
 import parseEmoji from './scripts/parse-emoji.mjs';
 import parseEmojiSequences from './scripts/parse-emoji-sequences.mjs';
 import parseNames from './scripts/parse-names.mjs';
@@ -168,6 +169,12 @@ const generateData = async (version) => {
 		'version': version,
 		'map': await parseVerticalOrientation(version),
 		'type': 'Vertical_Orientation',
+	}));
+	console.log('Parsing Unicode v%s `Joining_Type`…', version);
+	utils.extend(dirMap, await utils.writeFiles({
+		'version': version,
+		'map': await parseArabicShaping(version),
+		'type': 'Joining_Type',
 	}));
 	console.log('Parsing Unicode v%s binary emoji properties…', version);
 	utils.extend(dirMap, await utils.writeFiles({

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -64,6 +64,7 @@ const TYPES = [
 	'word-break',
 	'sentence-break',
 	'vertical-orientation',
+	'arabic-shaping',
 	'emoji',
 	'emoji-sequences',
 	'emoji-test',

--- a/scripts/parse-arabic-shaping.mjs
+++ b/scripts/parse-arabic-shaping.mjs
@@ -1,0 +1,27 @@
+import utils from './utils.mjs';
+import regenerate from 'regenerate';
+
+const parseArabicShaping = async (version) => {
+	const source = await utils.readDataFile(version, 'arabic-shaping');
+	if (!source) {
+		return;
+	}
+	const map = {};
+	const lines = source.split('\n');
+	for (const line of lines) {
+		if (!line || /^#/.test(line)) {
+			continue;
+		}
+		// Format: `0600; ARABIC NUMBER SIGN; U; No_Joining_Group`.
+		// Field 1 (schematic name) is a comment; field 2 is the
+		// Joining_Type value; field 3 (Joining_Group) is out of scope.
+		const data = line.trim().split(';');
+		const codePoint = parseInt(data[0].trim(), 16);
+		const joiningType = data[2].trim();
+		map[joiningType] ??= regenerate();
+		map[joiningType].add(codePoint);
+	}
+	return map;
+};
+
+export default parseArabicShaping;

--- a/tests/tests.mjs
+++ b/tests/tests.mjs
@@ -66,5 +66,9 @@ suite(`The generated latest Unicode js`, () => {
 			[...map.entries()]
 		);
 	});
+	test('Joining_Type/Dual_Joining should match the snapshot', async (t) => {
+		const { default: data } = await import(`../output/unicode-${newest}/Joining_Type/Dual_Joining/ranges.mjs`);
+		t.assert.snapshot(data);
+	});
 });
 


### PR DESCRIPTION
Fixes #101.Adds ArabicShaping.txt (Joining_Type) support so consumers implementing Arabic text shaping alongside a bidi algorithm (e.g. bidi-js, maplibre-gl-js#8343) can depend on this package instead of rolling their own UCD downloader.Changes:- scripts/parse-arabic-shaping.mjs (new): parses code; name; Joining_Type; Joining_Group lines into per-value regenerate sets (explicit entries only, mirroring parse-bidi-class; unlisted code points stay implicit per the file's T/U default rule, same as other parsers here).- scripts/download.mjs: arabic-shaping in TYPES.- data/resources.mjs: arabic-shaping URLs for Unicode 3.2.0 through 18.0.0 (legacy -Update layout for 3.2.0/4.0.0/4.0.1, ucd/ afterwards — every URL HEAD-verified 200).- index.mjs: wires Joining_Type generation (after Vertical_Orientation).- tests/tests.mjs: snapshot test for Joining_Type/Dual_Joining on the newest version (auto-created on first run, like other snapshots).Verification (offline, no clone needed): parser run against the real ArabicShaping-17.0.0.txt yields exactly the file's distribution (D615/R153/U50/C7/L5/T4, 834 entries, no ranges); spot checks U+0628=D, U+0627=R, U+0621=U, U+0600=U, U+0640=C, U+200D=C; unlisted U+061C correctly absent; missing-file versions return undefined so pre-3.2.0 outputs are unchanged. Generated Joining_Type/D artifacts verified end-to-end (ranges decode, 615 code points incl. U+0628). node --check clean on all touched files.Notes: Joining_Group is parsed but intentionally not emitted (single-map convention per writeFiles call); unlisted-codepoint defaults (T for marks, U otherwise) are left implicit per spec rather than materialized, matching how this repo treats bidi-class defaults.