### PR TITLE
Improve build performance

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import jsesc from 'jsesc';
@@ -28,11 +28,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const templatePath = path.resolve(__dirname, 'templates');
 const staticPath = path.resolve(__dirname, 'static');
-const compileReadMe = template(await fs.readFile(
+const compileReadMe = template(fs.readFileSync(
 	path.resolve(templatePath, 'README.md'),
 	'utf-8'
 ));
-const compilePackage = template(await fs.readFile(
+const compilePackage = template(fs.readFileSync(
 	path.resolve(templatePath, 'package.json'),
 	'utf-8'
 ));
@@ -42,7 +42,7 @@ const generateData = async (version) => {
 	const dirMap = {};
 	console.log('Generating data for Unicode v%s…', version);
 	console.log('Parsing Unicode v%s categories…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseDerivedGeneralCategory(version),
 		'type': (category) => {
@@ -53,74 +53,74 @@ const generateData = async (version) => {
 		},
 	}));
 	console.log('Parsing Unicode v%s `Bidi_Class`', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseBidiClass(version),
 		'type': 'Bidi_Class',
 	}));
 	console.log('Parsing Unicode v%s `Script`…', version);
 	const scriptsMap = await parsers.parseScripts(version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': scriptsMap,
 		'type': 'Script',
 	}));
 	console.log('Parsing Unicode v%s `Script_Extensions`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseScriptExtensions(version, scriptsMap),
 		'type': 'Script_Extensions',
 	}));
 	console.log('Parsing Unicode v%s properties…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseProperties(version),
 		'type': 'Binary_Property',
 	}));
 	console.log('Parsing Unicode v%s derived core properties…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseDerivedCoreProperties(version),
 		'type': 'Binary_Property',
 	}));
 	console.log('Parsing Unicode v%s derived binary properties…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseDerivedBinaryProperties(version),
 		'type': 'Binary_Property',
 	}));
 	console.log('Parsing Unicode v%s derived normalization properties…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseDerivedNormalizationProperties(version),
 		'type': 'Binary_Property',
 	}));
 	console.log('Parsing Unicode v%s composition exclusions…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseCompositionExclusions(version),
 		'type': 'Binary_Property',
 	}));
 	console.log('Parsing Unicode v%s `Case_Folding`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseCaseFolding(version),
 		'type': 'Case_Folding',
 	}));
 	console.log('Parsing Unicode v%s `Block`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseBlocks(version),
 		'type': 'Block',
 	}));
 	console.log('Parsing Unicode v%s `Bidi_Mirroring_Glyph`', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parsers.parseMirroring(version),
 		'type': 'Bidi_Mirroring_Glyph',
 	}));
 	console.log('Parsing Unicode v%s bidi brackets…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseBidiBrackets(version),
 		'type': 'Bidi_Paired_Bracket_Type',
@@ -128,87 +128,87 @@ const generateData = async (version) => {
 	{
 		const InPCName = +version.split('.')[0] >= 8 ? 'Indic_Positional_Category' : 'Indic_Matra_Category';
 		console.log('Parsing Unicode v%s `%s`…', version, InPCName);
-		utils.extend(dirMap, await utils.writeFiles({
+		utils.extend(dirMap, utils.writeFiles({
 			'version': version,
 			'map': await parseIndicPositionalCategory(version),
 			'type': InPCName,
 		}));
 	}
 	console.log('Parsing Unicode v%s `Indic_Syllabic_Category`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseIndicSyllabicCategory(version),
 		'type': 'Indic_Syllabic_Category',
 	}));
 	console.log('Parsing Unicode v%s `Line_Break`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseLineBreak(version),
 		'type': 'Line_Break',
 	}));
 	console.log('Parsing Unicode v%s `Grapheme_Cluster_Break`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseGraphemeWordSentenceBreak(version, 'grapheme-cluster-break'),
 		'type': 'Grapheme_Cluster_Break',
 	}));
 	console.log('Parsing Unicode v%s `Word_Break`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseGraphemeWordSentenceBreak(version, 'word-break'),
 		'type': 'Word_Break',
 	}));
 	console.log('Parsing Unicode v%s `Sentence_Break`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseGraphemeWordSentenceBreak(version, 'sentence-break'),
 		'type': 'Sentence_Break',
 	}));
 	console.log('Parsing Unicode v%s `Vertical_Orientation`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseVerticalOrientation(version),
 		'type': 'Vertical_Orientation',
 	}));
 	console.log('Parsing Unicode v%s `Joining_Type`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseArabicShaping(version),
 		'type': 'Joining_Type',
 	}));
 	console.log('Parsing Unicode v%s binary emoji properties…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseEmoji(version),
 		'type': 'Binary_Property',
 	}));
 	console.log('Parsing Unicode v%s emoji sequence properties…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseEmojiSequences(version),
 		'type': 'Sequence_Property',
 	}));
 	console.log('Parsing Unicode v%s `Names`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseNames(version),
 		'type': 'Names',
 	}));
 	console.log('Parsing Unicode v%s Aliases…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseNameAliases(version),
 		'type': 'Names',
 		'subType': 'name-aliases',
 	}));
 	console.log('Parsing Unicode v%s simple case mappings…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseSimpleCaseMapping(version),
 		'type': 'Simple_Case_Mapping',
 	}));
 	console.log('Parsing Unicode v%s `Special_Casing`…', version);
-	utils.extend(dirMap, await utils.writeFiles({
+	utils.extend(dirMap, utils.writeFiles({
 		'version': version,
 		'map': await parseSpecialCasing(version),
 		'type': 'Special_Casing',
@@ -219,7 +219,7 @@ const generateData = async (version) => {
 			dirMap[property] = dirMap[property].sort();
 		}
 	}
-	await fs.writeFile(
+	fs.writeFileSync(
 		path.resolve(__dirname, `output/unicode-${version}/README.md`),
 		compileReadMe({
 			'version': version,
@@ -227,21 +227,21 @@ const generateData = async (version) => {
 			'regenerateExample': '<%= set.toString() %>',
 		})
 	);
-	await fs.writeFile(
+	fs.writeFileSync(
 		path.resolve(__dirname, `output/unicode-${version}/index.mjs`),
 		compileIndex({ 'version': version, 'data': jsesc(dirMap) })
 	);
-	await fs.writeFile(
+	fs.writeFileSync(
 		path.resolve(__dirname, `output/unicode-${version}/index.d.mts`),
 		Object.keys(dirMap)
 			.map((key) => `export const ${key}: string[];`)
 			.join('\n')
 	);
-	await fs.writeFile(
+	fs.writeFileSync(
 		path.resolve(__dirname, `output/unicode-${version}/package.json`),
 		compilePackage({ 'version': version })
 	);
-	await fs.mkdir(
+	fs.mkdirSync(
 		path.resolve(__dirname, `output/unicode-${version}/.github/workflows`),
 		{
 			recursive: true,
@@ -258,7 +258,7 @@ const generateData = async (version) => {
 		'decode-ranges.d.mts',
 	];
 	for (const file of staticFiles) {
-		await fs.copyFile(
+		fs.copyFileSync(
 			path.resolve(staticPath, file),
 			path.resolve(__dirname, `output/unicode-${version}/${file}`)
 		);

--- a/scripts/download.mjs
+++ b/scripts/download.mjs
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import resources from '../data/resources.mjs';
@@ -17,7 +17,7 @@ const download = async (url, version, type) => {
 	if (!res.ok) {
 		throw new Error(`Failed to download ${url}: ${res.status} ${res.statusText}`);
 	}
-	await fs.writeFile(file, Buffer.from(await res.arrayBuffer()));
+	fs.writeFileSync(file, Buffer.from(await res.arrayBuffer()));
 };
 
 const parallelLimit = async (tasks, limit) => {

--- a/scripts/parse-arabic-shaping.mjs
+++ b/scripts/parse-arabic-shaping.mjs
@@ -13,7 +13,7 @@ const findCanonicalName = (shortName) => {
 };
 
 const parseArabicShaping = async (version) => {
-	const source = await utils.readDataFile(version, 'arabic-shaping');
+	const source = utils.readDataFile(version, 'arabic-shaping');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-bidi-brackets.mjs
+++ b/scripts/parse-bidi-brackets.mjs
@@ -13,7 +13,7 @@ const parseBidiBrackets = async (version) => {
 		'Close': regenerate(),
 		'None': regenerate().addRange(0, 0x10FFFF),
 	};
-	const source = await utils.readDataFile(version, 'bidi-brackets');
+	const source = utils.readDataFile(version, 'bidi-brackets');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-bidi-class.mjs
+++ b/scripts/parse-bidi-class.mjs
@@ -5,7 +5,7 @@ import regenerate from 'regenerate';
 const bidiAliases = valueAliases.get('Bidi_Class');
 
 const parseBidiClass = async (version) => {
-	const source = await utils.readDataFile(version, 'database');
+	const source = utils.readDataFile(version, 'database');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-blocks-scripts-properties.mjs
+++ b/scripts/parse-blocks-scripts-properties.mjs
@@ -33,7 +33,7 @@ const initialMapForType = (type) => {
  */
 const parseBlocksScriptsProperties = async (type, version) => {
 	const map = initialMapForType(type);
-	const source = await utils.readDataFile(version, type);
+	const source = utils.readDataFile(version, type);
 	if (!source) {
 		return;
 	}
@@ -106,7 +106,7 @@ const parseDerivedBinaryProperties = async (version) => {
 	if (version === '3.1.1' || version === '3.1.0' || version === '3.0.1' || version === '3.0.0' || parseInt(version.split('.')[0], 10) < 3) {
 		// Unicode <= 3.1.1 does not provide derived-binary-properties,
 		// so we should derive Bidi_Mirrored from the UnicodeData.
-		const source = await utils.readDataFile(version, 'database');
+		const source = utils.readDataFile(version, 'database');
 		if (!source) {
 			return;
 		}
@@ -137,7 +137,7 @@ const parseDerivedGeneralCategory = async (version) => {
 	) {
 		// Unicode <= 3.0.1 does not provide derived-general-category,
 		// so we should derive General_Category from the UnicodeData.
-		const source = await utils.readDataFile(version, 'database');
+		const source = utils.readDataFile(version, 'database');
 		if (!source) {
 			return;
 		}
@@ -257,7 +257,7 @@ const parseDerivedGeneralCategory = async (version) => {
 
 const parseBlocks = async (version) => {
 	if (version === '3.0.1' || version === '3.0.0' || parseInt(version.split('.')[0], 10) < 3) {
-		const source = await utils.readDataFile(version, 'blocks');
+		const source = utils.readDataFile(version, 'blocks');
 		if (!source) {
 			return;
 		}
@@ -285,7 +285,7 @@ const parseProperties = async (version) => {
 		version === '3.0.0' ||
 		parseInt(version.split('.')[0], 10) < 3
 	) {
-		const source = await utils.readDataFile(version, 'properties');
+		const source = utils.readDataFile(version, 'properties');
 		if (!source) {
 			return;
 		}

--- a/scripts/parse-case-folding.mjs
+++ b/scripts/parse-case-folding.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 
 const parseCaseFolding = async (version) => {
 	const caseFoldingMap = {};
-	const source = await utils.readDataFile(version, 'case-folding');
+	const source = utils.readDataFile(version, 'case-folding');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-composition-exclusions.mjs
+++ b/scripts/parse-composition-exclusions.mjs
@@ -2,7 +2,7 @@ import regenerate from 'regenerate';
 import utils from './utils.mjs';
 
 const parseCompositionExclusions = async (version) => {
-	const source = await utils.readDataFile(version, 'composition-exclusions');
+	const source = utils.readDataFile(version, 'composition-exclusions');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-emoji-sequences.mjs
+++ b/scripts/parse-emoji-sequences.mjs
@@ -1,7 +1,7 @@
 import utils from './utils.mjs';
 
 const parseEmojiSequencesWithId = async ({ version, id }) => {
-	const source = await utils.readDataFile(version, id);
+	const source = utils.readDataFile(version, id);
 	if (!source) {
 		return;
 	}
@@ -47,7 +47,7 @@ const parseEmojiSequencesWithId = async ({ version, id }) => {
 };
 
 const parseEmojiTestData = async ({ version }) => {
-	const source = await utils.readDataFile(version, 'emoji-test');
+	const source = utils.readDataFile(version, 'emoji-test');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-emoji.mjs
+++ b/scripts/parse-emoji.mjs
@@ -1,7 +1,7 @@
 import utils from './utils.mjs';
 
 const parseEmoji = async (version) => {
-	const source = await utils.readDataFile(version, 'emoji');
+	const source = utils.readDataFile(version, 'emoji');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-grapheme-word-sentence-break.mjs
+++ b/scripts/parse-grapheme-word-sentence-break.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 import regenerate from 'regenerate';
 
 const parseGraphemeWordSentenceBreak = async (version, kind) => {
-	const source = await utils.readDataFile(version, kind);
+	const source = utils.readDataFile(version, kind);
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-indic-positional-category.mjs
+++ b/scripts/parse-indic-positional-category.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 import regenerate from 'regenerate';
 
 const parseIndicPositionalCategory = async (version) => {
-	const source = await utils.readDataFile(version, 'indic-positional-category');
+	const source = utils.readDataFile(version, 'indic-positional-category');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-indic-syllabic-category.mjs
+++ b/scripts/parse-indic-syllabic-category.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 import regenerate from 'regenerate';
 
 const parseIndicSyllabicCategory = async (version) => {
-	const source = await utils.readDataFile(version, 'indic-syllabic-category');
+	const source = utils.readDataFile(version, 'indic-syllabic-category');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-line-break.mjs
+++ b/scripts/parse-line-break.mjs
@@ -13,7 +13,7 @@ const findCanonicalName = (shortName) => {
 };
 
 const parseLineBreak = async (version) => {
-	const source = await utils.readDataFile(version, 'line-break');
+	const source = utils.readDataFile(version, 'line-break');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-name-aliases.mjs
+++ b/scripts/parse-name-aliases.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 
 const parseNameAliases = async (version) => {
 	const map = {};
-	const source = await utils.readDataFile(version, 'name-aliases');
+	const source = utils.readDataFile(version, 'name-aliases');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-names.mjs
+++ b/scripts/parse-names.mjs
@@ -3,7 +3,7 @@ import regenerate from 'regenerate';
 
 const parseNames = async (version) => {
 	const map = {};
-	const source = await utils.readDataFile(version, 'database');
+	const source = utils.readDataFile(version, 'database');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-script-extensions.mjs
+++ b/scripts/parse-script-extensions.mjs
@@ -8,7 +8,7 @@ const findCanonicalName = (shortName) => {
 };
 
 const parseScriptExtensions = async (version, scriptsMap) => {
-	const source = await utils.readDataFile(version, 'script-extensions');
+	const source = utils.readDataFile(version, 'script-extensions');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-simple-case-mapping.mjs
+++ b/scripts/parse-simple-case-mapping.mjs
@@ -13,7 +13,7 @@ const parseSimpleCaseMapping = async (version) => {
 	// https://www.unicode.org/reports/tr44/#UnicodeData.txt
 	const columnIndexOfSimpleUppercaseMapping = 12;
 
-	const source = await utils.readDataFile(version, 'database');
+	const source = utils.readDataFile(version, 'database');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-special-casing.mjs
+++ b/scripts/parse-special-casing.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 
 const parseSpecialCasing = async (version) => {
 	const specialCasingMap = {};
-	const source = await utils.readDataFile(version, 'special-casing');
+	const source = utils.readDataFile(version, 'special-casing');
 	if (!source) {
 		return;
 	}

--- a/scripts/parse-vertical-orientation.mjs
+++ b/scripts/parse-vertical-orientation.mjs
@@ -2,7 +2,7 @@ import utils from './utils.mjs';
 import regenerate from 'regenerate';
 
 const parseVerticalOrientation = async (version) => {
-	const source = await utils.readDataFile(version, 'vertical-orientation');
+	const source = utils.readDataFile(version, 'vertical-orientation');
 	if (!source) {
 		return;
 	}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import zlib from 'node:zlib';
@@ -76,7 +76,7 @@ const samePropertyRuns = (codePointProperties) => {
 	return result;
 };
 
-const writeFiles = async (options) => {
+const writeFiles = (options) => {
 	const version = options.version;
 	const subType = options.subType;
 
@@ -140,18 +140,18 @@ const writeFiles = async (options) => {
 		}
 
 		// Create the target directory if it doesn’t exist yet.
-		await fs.mkdir(dir, { recursive: true });
+		fs.mkdirSync(dir, { recursive: true });
 		append(dirMap, type, subdir);
 
 		// Sequence properties are special.
 		if (type === 'Sequence_Property' || isNameAliases) {
 			const sequences = codePoints;
 			const output = `import { gunzipSync } from 'node:zlib';\n\nexport default ${ gzipInline(sequences) };\n`;
-			await fs.writeFile(
+			fs.writeFileSync(
 				path.resolve(dir, 'index.mjs'),
 				output
 			);
-			await fs.writeFile(
+			fs.writeFileSync(
 				path.resolve(dir, 'index.d.mts'),
 				type === 'Sequence_Property'
 					? `declare const data: string[];\nexport default data;\n`
@@ -167,19 +167,19 @@ const writeFiles = async (options) => {
 		let symbolsType = 'string[]';
 		if (!isCaseFoldingOrMapping) {
 			const encodedRanges = codePoints instanceof regenerate ? encodeRegenerate(codePoints) : encodeRanges(codePoints);
-			await fs.writeFile(
+			fs.writeFileSync(
 				path.resolve(dir, 'ranges.mjs'),
 				`import decodeRanges from '../../decode-ranges.mjs';\n\nexport default decodeRanges('${encodedRanges}');\n`
 			);
-			await fs.writeFile(
+			fs.writeFileSync(
 				path.resolve(dir, 'ranges.d.mts'),
 				'import type { UnicodeRange } from "../../decode-ranges.mjs";\n\ndeclare const ranges: UnicodeRange[];\nexport default ranges;\n'
 			);
-			await fs.writeFile(
+			fs.writeFileSync(
 				path.resolve(dir, 'regex.mjs'),
 				'export default /' + regenerate(codePoints).toString() + '/;\n'
 			);
-			await fs.writeFile(
+			fs.writeFileSync(
 				path.resolve(dir, 'regex.d.mts'),
 				'declare const regex: RegExp;\nexport default regex;\n'
 			);
@@ -213,19 +213,19 @@ const writeFiles = async (options) => {
 			}
 			symbolsType = 'Map<string, string>';
 		}
-		await fs.writeFile(
+		fs.writeFileSync(
 			path.resolve(dir, 'code-points.mjs'),
 			codePointsFileContent
 		);
-		await fs.writeFile(
+		fs.writeFileSync(
 			path.resolve(dir, 'code-points.d.mts'),
 			`declare const codePoints: ${ codePointsType };\nexport default codePoints;\n`
 		);
-		await fs.writeFile(
+		fs.writeFileSync(
 			path.resolve(dir, 'symbols.mjs'),
 			symbolsFileContent
 		);
-		await fs.writeFile(
+		fs.writeFileSync(
 			path.resolve(dir, 'symbols.d.mts'),
 			`declare const symbols: ${ symbolsType };\nexport default symbols;\n`
 		);
@@ -239,7 +239,7 @@ const writeFiles = async (options) => {
 		if (!hasKey(dirMap, type)) {
 			dirMap[type] = [];
 		}
-		await fs.mkdir(dir, { recursive: true });
+		fs.mkdirSync(dir, { recursive: true });
 		// `Bidi_Mirroring_Glyph/index.mjs`
 		// Note: `Bidi_Mirroring_Glyph` doesn’t have repeated strings; don’t gzip.
 		const output = [
@@ -249,11 +249,11 @@ const writeFiles = async (options) => {
 				JSON.stringify(bidiMirroringGlyphFlatPairs)
 			}.map((v, i, a) => pair(i & 1, a[i ^ 1], v)));\n`
 		].join('\n');
-		await fs.writeFile(
+		fs.writeFileSync(
 			path.resolve(dir, 'index.mjs'),
 			output
 		);
-		await fs.writeFile(
+		fs.writeFileSync(
 			path.resolve(dir, 'index.d.mts'),
 			`declare const data: Map<number, string>;\nexport default data;\n`
 		);
@@ -266,7 +266,7 @@ const writeFiles = async (options) => {
 			if (!hasKey(dirMap, type)) {
 				dirMap[type] = [];
 			}
-			await fs.mkdir(dir, { recursive: true });
+			fs.mkdirSync(dir, { recursive: true });
 			// `categories/index.mjs`
 			// or `Bidi_Class/index.mjs`
 			// or `bidi-brackets/index.mjs`
@@ -275,8 +275,8 @@ const writeFiles = async (options) => {
 			const output = `import { gunzipSync } from 'node:zlib';\nimport decodePropertyMap from '../decode-property-map.mjs';\n\nexport default decodePropertyMap(${gzipInline(
 				flatRuns
 			)});\n`;
-			await fs.writeFile(path.resolve(dir, 'index.mjs'), output);
-			await fs.writeFile(path.resolve(dir, 'index.d.mts'), `declare const map: Map<number, string>;\nexport default map;\n`);
+			fs.writeFileSync(path.resolve(dir, 'index.mjs'), output);
+			fs.writeFileSync(path.resolve(dir, 'index.d.mts'), `declare const map: Map<number, string>;\nexport default map;\n`);
 		}
 	}
 	return dirMap;
@@ -295,13 +295,13 @@ const extend = (destination, source) => {
 	}
 };
 
-const readDataFile = async (version, type) => {
+const readDataFile = (version, type) => {
 	const sourceFile = path.resolve(
 		__dirname, '..',
 		'data', version + '-' + type + '.txt'
 	);
 	try {
-		const source = await fs.readFile(sourceFile, 'utf-8');
+		const source = fs.readFileSync(sourceFile, 'utf-8');
 		return source;
 	} catch {
 		return;


### PR DESCRIPTION
This PR includes commits from #104, please review that PR first. I will rebase once that PR gets merged.

In https://github.com/node-unicode/node-unicode-data/commit/abf6544f566e67fb362a8de80f0f884e279f0183 we have replaced sync fs I/O with sequential async fs I/O, which is less efficient because of the async overhead.

In this PR we reverted the async fs I/O changes and as we can see the build time has been improved from 20s to 14s, a 1.4x performance gain.

Runtime measured in my local environment (Apple M1 Max 10c)
```
# Current main:
$ time npm run build
npm run build  19.99s user 43.52s system 435% cpu 14.588 total

# This PR:
$ time npm run build
npm run build  13.55s user 37.18s system 343% cpu 14.782 total
```